### PR TITLE
Added Spikeling, a neuron model implemented in arduino

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -45,3 +45,4 @@ https://github.com/less-smog/hardware
 https://github.com/8BitMixtape/8BitmixtapeNEO_BerlinerSchule_SZ-RDY
 https://github.com/emard/ulx3s
 https://github.com/monostable/ruler
+https://github.com/BadenLab/Spikeling


### PR DESCRIPTION
Added Spikeling, a neuron model implemented in arduino